### PR TITLE
yaml parsing uses `process.chdir`, which breaks deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,11 @@ class ServerlessApiCloudFrontPlugin {
 
   createDeploymentArtifacts() {
     const baseResources = this.serverless.service.provider.compiledCloudFormationTemplate;
-
+    const origDir = process.cwd();
     return this.serverless.yamlParser.parse(
       path.resolve(__dirname, 'resources.yml')
     ).then((resources) => {
+      process.chdir(origDir);
       this.prepareResources(resources);
       return _.merge(baseResources, resources);
     });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const _ = require('lodash');
 const chalk = require('chalk');
+const yaml = require('js-yaml');
+const fs = require('fs');
 
 class ServerlessApiCloudFrontPlugin {
   constructor(serverless, options) {
@@ -15,14 +17,15 @@ class ServerlessApiCloudFrontPlugin {
 
   createDeploymentArtifacts() {
     const baseResources = this.serverless.service.provider.compiledCloudFormationTemplate;
-    const origDir = process.cwd();
-    return this.serverless.yamlParser.parse(
-      path.resolve(__dirname, 'resources.yml')
-    ).then((resources) => {
-      process.chdir(origDir);
-      this.prepareResources(resources);
-      return _.merge(baseResources, resources);
+
+    const filename = path.resolve(__dirname, 'resources.yml');
+    const content = fs.readFileSync(filename, 'utf-8');
+    const resources = yaml.safeLoad(content, {
+      filename: filename
     });
+
+    this.prepareResources(resources);
+    return _.merge(baseResources, resources);
   }
 
   printSummary() {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "main": "index.js",
   "dependencies": {
     "chalk": "^2.0.0",
+    "js-yaml": "^3.10.0",
     "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
`this.serverless.yamlParser.parse` uses `process.chdir` to change the directory to yaml file, (which is `node_modules/serverless-api-cloudfront`) and that's why the deployment fails (the zip file cannot be found).
Unfortunately until [serverless/serverless#3875](https://github.com/serverless/serverless/pull/3875) is not resolved, there's no better way:(