### PR TITLE
ability to use multiple aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ custom:
       bucket: my-bucket.s3.amazonaws.com
       prefix: my-prefix
 ```
+
+### Notes
+
+* `domain` can be list, so if you want to add more domains, instead string you list multiple ones:
+
+```
+domain:
+  - my-custom-domain.com
+  - secondary-custom-domain.com
+```

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class ServerlessApiCloudFrontPlugin {
     const domain = this.getConfig('domain', null);
 
     if (domain !== null) {
-      distributionConfig.Aliases = [ domain ];
+      distributionConfig.Aliases = Array.isArray(domain) ? domain : [ domain ];
     } else {
       delete distributionConfig.Aliases;
     }


### PR DESCRIPTION
This changeset adds the ability to use multiple aliases while it's backward compatible. So it supports both configurations:

```
apiCloudFront:
    domain:
     - alias1.yourcompany.com
     - alias2.yourcompany.com
```

```
apiCloudFront:
    domain: alias1.yourcompany.com
```

If you like this change, I'm more than happy to update the README.md as well.