### PR TITLE
Add support for origin custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ custom:
       - page
       - per_page
     priceClass: PriceClass_100
+    originCustomHeaders:
+      - x-api-key: foo
+      - bar: quux
 ```
 
 ### Notes

--- a/index.js
+++ b/index.js
@@ -98,7 +98,14 @@ class ServerlessApiCloudFrontPlugin {
   }
 
   prepareOrigins(distributionConfig) {
-    distributionConfig.Origins[0].OriginPath = `/${this.options.stage}`;
+    const origin = _.head(distributionConfig.Origins)
+    const originCustomHeaders = this.getConfig('originCustomHeaders', [])
+
+    origin.OriginCustomHeaders = originCustomHeaders
+      .map(_.toPairs)
+      .map(_.head)
+      .map(_.partial(_.zipObject, ['HeaderName', 'HeaderValue']))
+    origin.OriginPath = `/${this.options.stage}`;
   }
 
   prepareCookies(distributionConfig) {


### PR DESCRIPTION
Add a possibility to define origin custom headers, such as `x-api-key`. 