### PR TITLE
Add section about IAM policys to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ minimumProtocolVersion: TLSv1
 
 ### IAM Policy
 
-In order to make this plugin work as expected a few additional IAM Policys might be needed on your AwS profile.
+In order to make this plugin work as expected a few additional IAM Policys might be needed on your AWS profile.
 
 More specifically this plugin needs the following policys attached:
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,17 @@ minimumProtocolVersion: TLSv1
 ```
 
 [minimum-protocol-version]: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html#cloudfront-Type-ViewerCertificate-MinimumProtocolVersion
+
+### IAM Policy
+
+In order to make this plugin work as expected a few additional IAM Policys might be needed on your AwS profile.
+
+More specifically this plugin needs the following policys attached:
+
+* `cloudfront:CreateDistribution`
+* `cloudfront:GetDistribution`
+* `cloudfront:UpdateDistribution`
+* `cloudfront:DeleteDistribution`
+* `cloudfront:TagResource`
+
+You can read more about IAM profiles and policys in the [Serverless documentation](https://serverless.com/framework/docs/providers/aws/guide/credentials#creating-aws-access-keys).

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ minimumProtocolVersion: TLSv1
 
 ### IAM Policy
 
-In order to make this plugin work as expected a few additional IAM Policys might be needed on your AWS profile.
+In order to make this plugin work as expected a few additional IAM Policies might be needed on your AWS profile.
 
-More specifically this plugin needs the following policys attached:
+More specifically this plugin needs the following policies attached:
 
 * `cloudfront:CreateDistribution`
 * `cloudfront:GetDistribution`
@@ -122,4 +122,4 @@ More specifically this plugin needs the following policys attached:
 * `cloudfront:DeleteDistribution`
 * `cloudfront:TagResource`
 
-You can read more about IAM profiles and policys in the [Serverless documentation](https://serverless.com/framework/docs/providers/aws/guide/credentials#creating-aws-access-keys).
+You can read more about IAM profiles and policies in the [Serverless documentation](https://serverless.com/framework/docs/providers/aws/guide/credentials#creating-aws-access-keys).


### PR DESCRIPTION
As mentioned in #22 this will add a section about which IAM policys are needed to make this plugin work.

The policys are determined by trial and error and are the ones needed if one uses the policies recommended by [Serverless](https://gist.github.com/ServerlessBot/7618156b8671840a539f405dea2704c8). Maybe I have missed any policy?

Closes #22